### PR TITLE
Fix incorrect syntax in action.js

### DIFF
--- a/action/action.js
+++ b/action/action.js
@@ -60,7 +60,7 @@ exports.onExecutePostLogin = async (event, api) => {
 
     const { requested_scopes } = event?.transaction;
 
-    if (!(Array.isArray(requested_scopes)) { 
+    if (!Array.isArray(requested_scopes)) { 
         console.log(`skip since scopes not invalid`);
         return;
     }


### PR DESCRIPTION
[This PR](https://github.com/abbaspour/client-initiated-account-linking/pull/4) introduced a syntax error in the action:

<img width="1399" alt="image" src="https://github.com/user-attachments/assets/57d8d1f3-889a-421c-a4c5-85ee3e94b453" />

You can see, the new changes have 3 opening parentheses, but only 2 closing.